### PR TITLE
Fixed example for dynamic data dropdown

### DIFF
--- a/form-runner/component/dynamic-data-dropdown.md
+++ b/form-runner/component/dynamic-data-dropdown.md
@@ -35,7 +35,7 @@ So far so good: assuming you have such a service that returns the data you need,
 <fr:databound-select1
     ref="city"
     appearance="minimal"
-    resource="/xforms-sandbox/service/zip-cities?state-abbreviation={state}">
+    resource="/xforms-sandbox/service/zip-cities?state-abbreviation={../state}">
     <xf:label>City</xf:label>
     <xf:itemset ref="/cities/city">
         <xf:label ref="@name"/>


### PR DESCRIPTION
The example in https://doc.orbeon.com/form-runner/components/dynamic-data-dropdown doesn't seem to work in our version of Orbeon.

Looking at the linked code example[1], the replacement token in the resource path contains `{../state}` instead of just `{state}` (from the docs).

I'm not sure if this may relate to different versions of Orbeon, but it would be good to call it out if it is, so the docs don't contradict the code example.

Many thanks.

[1] https://github.com/orbeon/orbeon-forms/blob/master/form-runner/jvm/src/main/resources/xbl/orbeon/databound-select1/databound-select1-unittest.xhtml#L46